### PR TITLE
Kaizen/improve file type

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ Run `docker-compose run app` or `make run` to execute code from docker
 
 Full commands to run unit and coverage tests
 
-1. `docker-compose run app pytest args=[FILE_NAME]` Single unit test file 
-2. `docker-compose run app pytest args=[FOLDER_NAME]/` Multi unit tests in folder 
+1. `docker-compose run app pytest` Multi unit tests in `tests` folder 
+2. `docker-compose run app pytest args=[PATH_TO/FILE_NAME]` Single unit test file 
 3. `docker-compose run app pytest --cov=. [FOLDER_NAME]/` Coverage tests 
 
 You can use the following alias to run unit and coverage tests
-1. `make test [args=FILE_NAME]` file name in this command is optional.  It will run test in a single file if `args=PATH_TO/FILE_NAME` is given, otherwise, it will run through all tests in code base
+1. `make test [args=PATH_TO/FILE_NAME]` section inside `[]` is optional.  It will run test in a single file if `args=PATH_TO/FILE_NAME` is given, otherwise, it will run through all tests in code base
 2. `make coverage` It will provide you code coverage for entire code base
 
 

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ Run `docker-compose run app` or `make run` to execute code from docker
 
 Full commands to run unit and coverage tests
 
-1. `docker-compose run app pytest [FILE_NAME]` Single unit test file 
-2. `docker-compose run app pytest [FOLDER_NAME]/` Multi unit tests in folder 
+1. `docker-compose run app pytest args=[FILE_NAME]` Single unit test file 
+2. `docker-compose run app pytest args=[FOLDER_NAME]/` Multi unit tests in folder 
 3. `docker-compose run app pytest --cov=. [FOLDER_NAME]/` Coverage tests 
 
 You can use the following alias to run unit and coverage tests
-1. `make test [FILE_NAME]` file name in this command is optional.  It will run test in a single file if `FILE_NAME` is given, otherwise, it will run through all tests in code base
+1. `make test [args=FILE_NAME]` file name in this command is optional.  It will run test in a single file if `args=PATH_TO/FILE_NAME` is given, otherwise, it will run through all tests in code base
 2. `make coverage` It will provide you code coverage for entire code base
 
 

--- a/makefile
+++ b/makefile
@@ -9,7 +9,7 @@ run:
 	docker-compose run --rm app
 
 test:
-	docker-compose run --rm app pytest tests/${argv}
+	docker-compose run --rm app pytest tests/${args}
 
 coverage:
 	docker-compose run --rm app pytest --cov=. tests/

--- a/src/file_io/models.py
+++ b/src/file_io/models.py
@@ -1,10 +1,17 @@
-class FileType:
+from enum import Enum
+
+
+class FileType(Enum):
     CSV = "csv"
+    UNSUPPORTED = "unsupported"
 
     @classmethod
-    def __get_file_extension(cls, file_name: str) -> str:
-        return file_name.split(".")[-1]
+    def get_type_for_file_name(cls, file_name):
+        if not file_name:
+            return cls.UNSUPPORTED
 
-    @classmethod
-    def is_csv(cls, file_name) -> bool:
-        return cls.__get_file_extension(file_name).lower() == cls.CSV
+        file_extension = file_name.split(".")[-1].lower()
+        if file_extension == cls.CSV.value:
+            return cls.CSV
+        else:
+            return cls.UNSUPPORTED

--- a/src/file_io/reader.py
+++ b/src/file_io/reader.py
@@ -10,7 +10,8 @@ LOGGER = logging.getLogger(__name__)
 
 
 def get_file_reader(file_name: str):
-    if FileType.is_csv(file_name):
+    file_type = FileType.get_type_for_file_name(file_name)
+    if file_type == FileType.CSV:
         return read_csv_file
     else:
         raise FileExtensionNotFoundException(f"Unable to read from '{file_name}")

--- a/src/file_io/writer.py
+++ b/src/file_io/writer.py
@@ -8,12 +8,14 @@ LOGGER = logging.getLogger(__name__)
 
 
 def get_content_formatter(file_name: str):
-    if FileType.is_csv(file_name):
-        return csv_formatter
-    else:
+    file_type = FileType.get_type_for_file_name(file_name)
+    if file_type == FileType.UNSUPPORTED:
         raise FileExtensionNotFoundException(
             f"Unsupported file output format `{file_name}`"
         )
+
+    if file_type == FileType.CSV:
+        return csv_formatter
 
 
 def csv_formatter(contents):

--- a/src/file_io/writer.py
+++ b/src/file_io/writer.py
@@ -9,13 +9,12 @@ LOGGER = logging.getLogger(__name__)
 
 def get_content_formatter(file_name: str):
     file_type = FileType.get_type_for_file_name(file_name)
-    if file_type == FileType.UNSUPPORTED:
+    if file_type == FileType.CSV:
+        return csv_formatter
+    else:
         raise FileExtensionNotFoundException(
             f"Unsupported file output format `{file_name}`"
         )
-
-    if file_type == FileType.CSV:
-        return csv_formatter
 
 
 def csv_formatter(contents):

--- a/src/tests/test_file_io/test_models.py
+++ b/src/tests/test_file_io/test_models.py
@@ -1,0 +1,18 @@
+from file_io.models import FileType
+from tests.base import TestCase
+
+
+class ModelsTestCase(TestCase):
+    def test_get_type_for_file_name_with_csv(self):
+        FILE_NAME = "test.csv"
+        file_type = FileType.get_type_for_file_name(FILE_NAME)
+        self.assertEqual(file_type, FileType.CSV)
+
+    def test_get_type_for_file_name_with_unsupported(self):
+        FILE_NAME = "test"
+        file_type = FileType.get_type_for_file_name(FILE_NAME)
+        self.assertEqual(file_type, FileType.UNSUPPORTED)
+
+    def test_get_type_for_file_name_with_none(self):
+        file_type = FileType.get_type_for_file_name(None)
+        self.assertEqual(file_type, FileType.UNSUPPORTED)


### PR DESCRIPTION
## Description

Refactor `FileType` class into enum to better isolate logic, and enforce this class to only know and handle the type of file.  Caller can decide want to do when they receive the type.  Keep business log more isolated between each other

## Test

Add the code into `run.py` and execuete `make run`
Validate output in here matches output in `master`
```python
from file_io.reader import read_from_file
from file_io.writer import write_to_file

contents = read_from_file("input.csv")
print(contents)
write_to_file("output.csv", contents)
```